### PR TITLE
add CheckDigit for DPD

### DIFF
--- a/couriers/dpd.json
+++ b/couriers/dpd.json
@@ -5,10 +5,33 @@
       {
         "name": "DPD",
         "regex": [
-          "\\s*(?<SerialNumber>(\\d{14}[A-Z\\d]|\\d{14}|\\d{12}|\\d{10}]))\\s*"
+          "\\s*(?<DepotCode>(\\d{0,4}))(?<ServiceType>(\\d{2}))(?<SerialNumber>(\\d{8}))(?<CheckDigit>([A-Z\\d]))\\s*"
         ],
         "validation": {
+          "checksum": {
+            "name": "mod36"
+          }
         },
+        "additional": [
+          {
+            "name": "Service Type",
+            "regex_group_name": "ServiceType",
+            "lookup": [
+              {
+                "matches_regex": "[0-4][0-9]",
+                "name": "Standard parcel labels"
+              },
+              {
+                "matches_regex": "[5-8][0-9]|9[0-8]",
+                "name": "Parcel labels printed by the customer"
+              },
+              {
+                "matches": "99",
+                "name": "DPD GmbH & Co. (for special purposes)"
+              }
+            ]
+          }
+        ],
         "tracking_url": "https://tracking.dpd.de/status/en_US/parcel/%s",
         "test_numbers": {
           "valid": [


### PR DESCRIPTION
@lyleunderwood it seems users are not inputting the CheckDigit in elastic - the Check appears on the website but not in our database, at least not scramble side. Note the "B" in the screenshot.

![Screenshot 2020-06-30 at 16 22 04](https://user-images.githubusercontent.com/20900798/86137771-f04fd280-baed-11ea-9d3a-44f4ba50dd1a.png)
![Screenshot 2020-06-30 at 16 21 52](https://user-images.githubusercontent.com/20900798/86137778-f0e86900-baed-11ea-92fa-c7c7c6a02b56.png)



Edit: screenshot for verification purposes - it should match the file change.

![Screenshot 2020-06-30 at 16 24 23](https://user-images.githubusercontent.com/20900798/86138053-3efd6c80-baee-11ea-877e-b85e70ca8fb8.png)
