### PR TITLE
ElasticSuite/scramble4#10163 bring

### DIFF
--- a/couriers/bring.json
+++ b/couriers/bring.json
@@ -1,0 +1,23 @@
+{
+  "name": "Bring",
+  "courier_code": "bring",
+  "tracking_numbers": [
+    {
+      "name": "DPD",
+      "regex": [
+        "\\s*(?<SerialNumber>(3\\d{17}|07\\d{16}|7\\d{16}|[a-zA-Z]{2}\\d{9}[a-zA-Z]{2}))\\s*"
+      ],
+      "validation": {
+      },
+      "tracking_url": "https://tracking.bring.com/tracking/%s",
+      "test_numbers": {
+        "valid": [
+          "070400500051090146"
+        ],
+        "invalid": [
+          "TBB000000000000"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
ElasticSuite/scramble4#10163 bring

https://www.bring.no/english/receiving/tracking
`An item or parcel number generally has 13 characters (2 letters + 9 numbers + 2 letters) or a number series that begins with 3 (18 digits) or 7 (17 digits). Enter the entire combination - for example: CS111111111NO or 370733344455566677.`